### PR TITLE
CouchDB does not enforce 'use strict'

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,6 @@
 	limitations under the License.
 */
 
-"use strict";
-
 var PouchPluginError = require("pouchdb-plugin-error");
 var extend = require("extend");
 


### PR DESCRIPTION
So maybe removing this global 'use strict' statement functions written in a non-strict form that work on CouchDB will work also in PouchDB.

See https://botbot.me/freenode/pouchdb/2015-09-09/?msg=49380965&page=2
